### PR TITLE
Improved developer operations for sadeaf-hasura

### DIFF
--- a/sadeaf-hasura/Dockerfile
+++ b/sadeaf-hasura/Dockerfile
@@ -2,7 +2,7 @@ FROM hasura/graphql-engine:v1.3.0.cli-migrations-v2
 
 EXPOSE 8080
 
-ADD ./migrations /hasura-migrations
-ADD ./metadata /hasura-metadata
-
 ENV HASURA_GRAPHQL_ENABLE_CONSOLE "false"
+
+ADD ./metadata /hasura-metadata
+ADD ./migrations /hasura-migrations

--- a/sadeaf-hasura/README.md
+++ b/sadeaf-hasura/README.md
@@ -1,11 +1,10 @@
 # Setting up Hasura in a DEV environment
 Make sure you have docker installed locally.
 
-1. Install dependencies with `yarn install`
-2. Run `yarn workspace sadeaf-hasura console`
-3. The Hasura console will automatically pop up in your default browser
-
-> If this is a fresh build, step 2 will fail with an error like `FATA[0002] version check: failed to get version from server: failed making version api call`. Just make sure the containers are up then run the command again. 
+1. Install [docker](https://docs.docker.com/get-docker/) & [docker-compose](https://docs.docker.com/compose/)
+2. Install dependencies with `yarn install`
+3. Run `yarn workspace sadeaf-hasura console`
+4. The Hasura console will automatically pop up in your default browser
 
 # How it works
 - The files in `/metadata` are used by Hasura to track the state of all tables in the psql db. It is also what 
@@ -14,6 +13,7 @@ Hasura uses to infer relationships between tables (eg. Client is a child of Acco
 
 # Making changes
 Remember to commit any schema or metadata changes.
+
 ### Schema changes
 - Make psql db changes on the Hasura console
 - The migration will automatically appear in `/migration`

--- a/sadeaf-hasura/config.yaml
+++ b/sadeaf-hasura/config.yaml
@@ -1,6 +1,7 @@
 version: 2
 endpoint: http://localhost:8080
 metadata_directory: metadata
+migrations_directory: migrations
 actions:
   kind: synchronous
   handler_webhook_baseurl: http://localhost:3000

--- a/sadeaf-hasura/docker-compose.yml
+++ b/sadeaf-hasura/docker-compose.yml
@@ -6,16 +6,15 @@ services:
     environment:
       POSTGRES_PASSWORD: postgrespassword
       POSTGRES_DB: sadeaf_app
-  graphql-engine:
+
+  hasura:
     build: .
     ports:
-    - "8080:8080"
+      - "8080:8080"
     depends_on:
-    - "postgres"
+      - postgres
     restart: always
     environment:
       HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:postgrespassword@postgres:5432/sadeaf_app
-      ## enable debugging mode. It is recommended to disable this in production
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
-      ## uncomment next line to set an admin secret

--- a/sadeaf-hasura/package.json
+++ b/sadeaf-hasura/package.json
@@ -3,7 +3,7 @@
   "name": "sadeaf-hasura",
   "version": "1.0.0",
   "scripts": {
-    "console": "docker-compose up -d --build && hasura migrate apply && hasura metadata apply && hasura console"
+    "console": "docker-compose up -d --build && sh ./wait-for-hasura-console"
   },
   "dependencies": {},
   "devDependencies": {

--- a/sadeaf-hasura/wait-for-hasura-console
+++ b/sadeaf-hasura/wait-for-hasura-console
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+TIMEOUT=45
+
+# config.yaml:endpoint
+ENDPOINT="http://localhost:8080/v1/version"
+
+wait_for() {
+  for _ in $(seq $TIMEOUT) ; do
+    result=$(curl $ENDPOINT -o /dev/null -w '%{http_code}\n' -s)
+
+    if [ "$result" -eq "200" ] ; then
+      exec "$@"
+      exit 0
+    fi
+    sleep 3
+    echo "Still waiting for hasura to be up..."
+
+  done
+  echo "wait-for-hasura-console timed out" >&2
+  exit 1
+}
+
+echo "Waiting for hasura to be up"
+wait_for hasura console


### PR DESCRIPTION
# What changes are made in this PR?
* Added script `wait-for-hasura-console` so that hasura console will only start after hasura is up
* Removed hasura migration and metadata apply in `package.json:scripts:console` since the image will apply them automatically
* Rearranged `Dockerfile` steps by moving mutable commands down to make use of docker build caching