### PR TITLE
[DevOps] GitHub Actions to build and publish images

### DIFF
--- a/.github/workflows/pr_master_api.yml
+++ b/.github/workflows/pr_master_api.yml
@@ -1,0 +1,42 @@
+name: Pull request to master, sadeaf-api
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'sadeaf-api/**'
+      - '!sadeaf-api/tests/**'
+      - '!sadeaf-api/**.md'
+
+jobs:
+  build_image:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v1
+        with:
+          path: sadeaf-api
+          registry: docker.pkg.github.com
+          repository: SADEAFxSMU/sadeaf-app/sadeaf-api
+          tags: latest
+          push: false
+
+  run_yarn_test:
+    name: Run yarn test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+
+      - run: yarn install
+        working-directory: sadeaf-api
+
+      - run: yarn test
+        working-directory: sadeaf-api

--- a/.github/workflows/pr_master_hasura.yml
+++ b/.github/workflows/pr_master_hasura.yml
@@ -1,0 +1,26 @@
+name: Pull request to master, sadeaf-hasura
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'sadeaf-hasura/**'
+      - '!sadeaf-hasura/tests/**'
+      - '!sadeaf-hasura/**.md'
+
+jobs:
+  build_image:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v1
+        with:
+          path: sadeaf-hasura
+          registry: docker.pkg.github.com
+          repository: SADEAFxSMU/sadeaf-app/sadeaf-hasura
+          tags: latest
+          push: false

--- a/.github/workflows/pr_master_web.yml
+++ b/.github/workflows/pr_master_web.yml
@@ -1,0 +1,41 @@
+name: Pull request to master, sadeaf-web
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'sadeaf-web/**'
+      - '!sadeaf-web/test/**'
+
+jobs:
+  build_image:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v1
+        with:
+          path: sadeaf-web
+          registry: docker.pkg.github.com
+          repository: SADEAFxSMU/sadeaf-app/sadeaf-web
+          tags: latest
+          push: false
+
+  run_yarn_test:
+    name: Run yarn test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+
+      - run: yarn install
+        working-directory: sadeaf-web
+
+      - run: yarn test
+        working-directory: sadeaf-web

--- a/.github/workflows/pr_master_worker.yml
+++ b/.github/workflows/pr_master_worker.yml
@@ -1,0 +1,42 @@
+name: Pull request to master, sadeaf-worker
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'sadeaf-worker/**'
+      - '!sadeaf-worker/tests/**'
+      - '!sadeaf-worker/**.md'
+
+jobs:
+  build_image:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v1
+        with:
+          path: sadeaf-worker
+          registry: docker.pkg.github.com
+          repository: SADEAFxSMU/sadeaf-app/sadeaf-worker
+          tags: latest
+          push: false
+
+  run_yarn_test:
+    name: Run yarn test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+
+      - run: yarn install
+        working-directory: sadeaf-worker
+
+      - run: yarn test
+        working-directory: sadeaf-worker

--- a/.github/workflows/release_published.yml
+++ b/.github/workflows/release_published.yml
@@ -1,0 +1,53 @@
+name: Publish Docker image to GitHub Packages on publishing release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release_to_registry:
+    name: Build and publish Docker images to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Build sadeaf-api and push to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          path: sadeaf-api
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: SADEAFxSMU/sadeaf-app/sadeaf-api
+          tag_with_ref: true
+
+      - name: Build sadeaf-hasura and push to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          path: sadeaf-hasura
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: SADEAFxSMU/sadeaf-app/sadeaf-hasura
+          tag_with_ref: true
+
+      - name: Build sadeaf-web and push to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          path: sadeaf-web
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: SADEAFxSMU/sadeaf-app/sadeaf-web
+          tag_with_ref: true
+
+      - name: Build sadeaf-worker and push to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          path: sadeaf-worker
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: SADEAFxSMU/sadeaf-app/sadeaf-worker
+          tag_with_ref: true


### PR DESCRIPTION
* Added publish Docker image on publishing release workflow (using git tag as docker image tag)
* Added build and test all 4 modules on a pull request to master workflow

# Caveats
> Highly likely, we will hit these limits.

### Free tier & thereafter
- Storage for Actions and Packages
  - Free: 0.5 GB per month
  - $0.25 per GB per month
- GitHub Packages data transfer out 
  - Free: 1.0 GB per month
  - $0.5 per GB per month
- GitHub Actions (Linux)
  - Free: 2000 minutes per month
  - $0.8 per 100 minutes

Previously I wanted to store them in AWS ECR since the quota of 5 GB is much more generous. But we have to use GitHub packages if we are using the multi AWS account approach. This is to allow multiple accounts to access and pull from GitHub Packages easily without requiring to push into AWS, thus making AWS a transient environment.

The cost per month is relatively cheap for storage and active CI/CD pipelines while we are developing the product. 
@elihuansen we will likely need to attach a debit card here as well and SADEAF has to take over this cost.

# How has this been tested?
Not tested, we can wait for it to run naturally and fix it if there are any issues.