### PR TITLE
[Hasura] Exposed a webhook endpoint in worker for Hasura 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:postgrespassword@postgres:5432/sadeaf_app
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
+      SVC_SADEAF_WORKER_URL: http://sadeaf-worker:5000
 
   sadeaf-worker:
     build: sadeaf-worker

--- a/sadeaf-hasura/Dockerfile
+++ b/sadeaf-hasura/Dockerfile
@@ -3,6 +3,7 @@ FROM hasura/graphql-engine:v1.3.0.cli-migrations-v2
 EXPOSE 8080
 
 ENV HASURA_GRAPHQL_ENABLE_CONSOLE "false"
+ENV SVC_SADEAF_WORKER_URL "http://localhost:5000"
 
 ADD ./metadata /hasura-metadata
 ADD ./migrations /hasura-migrations

--- a/sadeaf-worker/package.json
+++ b/sadeaf-worker/package.json
@@ -10,7 +10,7 @@
     "tests": "test"
   },
   "scripts": {
-    "test": "sh ../docker-compose-up localstack mailhog sadeaf-hasura && node wait-for.js && tap tests/*/**.test.js tests/**.test.js",
+    "test": "sh ../docker-compose-up && node wait-for.js && tap tests/*/**.test.js tests/**.test.js",
     "start": "node index.js",
     "dev": "sh ../docker-compose-up && supervisor index.js"
   },

--- a/sadeaf-worker/src/controller.js
+++ b/sadeaf-worker/src/controller.js
@@ -1,6 +1,9 @@
+const {getQueue: sqsGetQueue} = require('./queue')
+
 class Controller {
   constructor(workers) {
     this.workers = workers
+    this.queues = {}
   }
 
   start(fastify) {
@@ -10,6 +13,31 @@ class Controller {
       const ok = this.workers.every((worker) => worker.health())
       reply.code(ok ? 200 : 400).send({ok})
     })
+
+    fastify.post('/hasura/webhook/:queue', (request, reply) => {
+      const queueName = request.params.queue
+      const json = JSON.stringify(request.body)
+
+      this.getQueue(queueName)
+        .then(async (q) => {
+          await q.sendMessage(json)
+        })
+        .then(() => reply.code(200).send({}))
+        .catch((err) => reply.send(err))
+    })
+  }
+
+  /**
+   *
+   * @param queueName
+   * @return {Promise<Queue>}
+   */
+  async getQueue(queueName) {
+    if (!this.queues[queueName]) {
+      this.queues[queueName] = await sqsGetQueue(queueName)
+    }
+
+    return this.queues[queueName]
   }
 
   stop() {

--- a/sadeaf-worker/src/queue.js
+++ b/sadeaf-worker/src/queue.js
@@ -19,10 +19,17 @@ function getSqs() {
 }
 
 class Queue {
+
+  /**
+   * @param queueUrl
+   */
   constructor(queueUrl) {
     this.queueUrl = queueUrl
   }
 
+  /**
+   * @return {Promise<[string]>}
+   */
   getMessages() {
     const params = {
       MaxNumberOfMessages: 10,
@@ -65,6 +72,11 @@ class Queue {
     })
   }
 
+  /**
+   * Delete message in the queue
+   * @param message
+   * @return {Promise}
+   */
   deleteMessage(message) {
     const deleteParams = {
       QueueUrl: this.queueUrl,
@@ -85,13 +97,16 @@ class Queue {
 
 module.exports = {
 
+  /**
+   * @return {Promise<[string]>}
+   */
   list() {
     return new Promise((resolve, reject) => {
       sqs.listQueues(function (err, data) {
         if (err) {
           reject(err)
         } else {
-          resolve()
+          resolve(data.QueueUrls)
         }
       })
     })

--- a/sadeaf-worker/src/workers/abstract.js
+++ b/sadeaf-worker/src/workers/abstract.js
@@ -48,7 +48,7 @@ class Worker {
 
         for (const message of messages) {
           this.options.onReceiveMessage.call(this, JSON.parse(message.Body), () => {
-            this.queue.deleteMessage(message)
+            return this.queue.deleteMessage(message)
               .catch((err) => this.logger.error(err))
           }, message.Attributes)
         }

--- a/sadeaf-worker/tests/webhook.test.js
+++ b/sadeaf-worker/tests/webhook.test.js
@@ -1,0 +1,52 @@
+const {test} = require('tap')
+const Fastify = require('fastify')
+
+const Controller = require("../src/controller")
+const {createQueue, deleteQueue} = require('../src/queue')
+const {Worker} = require("../src/workers/abstract")
+const {sleep} = require("./helper")
+
+async function setup(t, onReceiveMessage) {
+  const queueName = "WebHookQueue"
+  await createQueue(queueName)
+
+  const controller = Controller([
+    new Worker(queueName, {
+      cycleTime: 1000,
+      dieAfter: 1,
+      onReceiveMessage,
+    })
+  ])
+
+  const fastify = Fastify()
+  controller.start(fastify)
+
+  t.tearDown(fastify.close.bind(fastify))
+  t.tearDown(() => controller.stop())
+  t.tearDown(async () => {
+    await sleep(1000)
+    await deleteQueue(queueName)
+  })
+
+  return fastify
+}
+
+test('/hasura/webhook/WebHookQueue', (t) => {
+  t.plan(2)
+  t.setTimeout(6000)
+
+  setup(t, (payload, done) => {
+    done()
+    t.equal(payload.id, "123")
+    t.equal(payload.string, "Okay")
+  }).then((fastify) => {
+    fastify.inject({
+      url: '/hasura/webhook/WebHookQueue',
+      method: "POST",
+      payload: {
+        id: "123",
+        string: "Okay"
+      }
+    })
+  })
+})


### PR DESCRIPTION
* Added webhook trigger in worker to enqueue data into SQS.

# Caveats
> Increased complexity in services, worker being tighly coupled with hasura.

```txt
             SADEAF SERVICES

+-------+      +-------+       +----------+
|  WEB  +----->+  API  +------>+  HASURA  |
+-------+      +-------+       +--+----+--+
                                  |    ^
                                  |    |
                                  v    |
                               +--+----+--+
                               |  WORKER  |
                               +----------+
``` 

# Checklist
<!-- Delete items if they are not applicable -->

- [x] I have written new tests
- [x] New and existing tests pass successfully
