### PR TITLE
Prevent hasura console to prompt for update

### DIFF
--- a/sadeaf-hasura/config.yaml
+++ b/sadeaf-hasura/config.yaml
@@ -2,6 +2,7 @@ version: 2
 endpoint: http://localhost:8080
 metadata_directory: metadata
 migrations_directory: migrations
+show_update_notification: false
 actions:
   kind: synchronous
   handler_webhook_baseurl: http://localhost:3000


### PR DESCRIPTION
# What changes are made in this PR?
Prevent hasura console to prompt for update. Address #27 

# How has this been tested?
You shouldn't see any update messages when running `yarn console` 