### PR TITLE
Removed process.env.TELEGRAM_WEBHOOK_URL as it's an aesthetic variable

### DIFF
--- a/sadeaf-web/config.js
+++ b/sadeaf-web/config.js
@@ -46,7 +46,6 @@ module.exports = {
   },
   TELEGRAM: {
     WEBHOOK_ENDPOINT: process.env.TELEGRAM_WEBHOOK_ENDPOINT || 'http://localhost:4001/',
-    WEBHOOK_URL: process.env.TELEGRAM_WEBHOOK_URL || 'https://sadeaftest.tunnelto.dev/_telegram/webhook',
     BASE_URL: `https://api.telegram.org/bot${process.env.SADEAF_TELEGRAM_API_KEY}`,
   },
   BOOTSTRAP: {

--- a/sadeaf-web/telegram/server.js
+++ b/sadeaf-web/telegram/server.js
@@ -1,12 +1,9 @@
 import express from 'express';
 import bodyParser from 'body-parser';
-import { PRODUCTION } from '../config';
 import { INVALID_MESSAGE } from './registration-messages';
 import { getRegisterMessage, getStartMessage } from './actions';
 
-const {
-  TELEGRAM: { WEBHOOK_URL },
-} = require('../config');
+const { PRODUCTION } = require('../config');
 
 export default {
   async start(port) {
@@ -53,14 +50,16 @@ export default {
 
     return new Promise((resolve, reject) => {
       app.listen(port, (err) => {
-        if (err) reject(err);
-        else {
-          if (!PRODUCTION) {
-            console.warn('Remember to install tunnelto and run -> tunnelto --port 3000 -s sadeaftest');
-          }
-          console.log(`Telegram webhook listening on: ${WEBHOOK_URL}`);
-          resolve();
+        if (err) {
+          return reject(err);
         }
+
+        if (!PRODUCTION) {
+          console.warn('Remember to install tunnelto and run -> tunnelto --port 3000 -s sadeaftest');
+          console.warn(`Telegram webhook listening on: https://sadeaftest.tunnelto.dev/_telegram/webhook`);
+        }
+
+        resolve();
       });
     });
   },


### PR DESCRIPTION
Preparation for https://github.com/SADEAFxSMU/sadeaf-aws/issues/41
Implemented in https://github.com/SADEAFxSMU/sadeaf-aws/pull/42

Removed 'TELEGRAM_WEBHOOK_URL' because it does nothing as it's only use for development and cannot be set locally. It's a variable/setting beyond our control.